### PR TITLE
Fix off-by-one access at the end of the vec array in pgfincore_file()…

### DIFF
--- a/pgfincore.c
+++ b/pgfincore.c
@@ -822,7 +822,7 @@ pgfincore_file(char *filename, pgfincoreStruct *pgfncr)
 		x = HIGHBIT;
 
 		/* handle the results */
-		for (pageIndex = 0; pageIndex <= pgfncr->rel_os_pages; pageIndex++)
+		for (pageIndex = 0; pageIndex < pgfncr->rel_os_pages; pageIndex++)
 		{
 			// block in memory
 			if (vec[pageIndex] & FINCORE_PRESENT)


### PR DESCRIPTION
When running the `pgfincore` tests with memory sanitization checks, we observed the following warning:

```
==5712==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x7f1ef0a1ad6e in pgfincore_file pgfincore/pgfincore.c:828:23
    #1 0x7f1ef0a1ad6e in pgfincore pgfincore/pgfincore.c:987:11
    #2 0x5578a59e96dc in ExecMakeTableFunctionResult postgres/src/backend/executor/execSRF.c:234:13
    #3 0x5578a5a19ed7 in FunctionNext postgres/src/backend/executor/nodeFunctionscan.c:94:5
    #4 0x5578a59ebefe in ExecScanFetch postgres/src/include/executor/execScan.h:134:9
    #5 0x5578a59ebefe in ExecScanExtended postgres/src/include/executor/execScan.h:178:10
    #6 0x5578a59ebefe in ExecScan postgres/src/backend/executor/execScan.c:59:9
    #7 0x5578a5a19626 in ExecFunctionScan postgres/src/backend/executor/nodeFunctionscan.c:269:9
    #8 0x5578a59e5054 in ExecProcNodeFirst postgres/src/backend/executor/execProcnode.c:469:9
    #9 0x5578a59d1593 in ExecProcNode postgres/src/include/executor/executor.h:315:9
    #10 0x5578a59d1593 in ExecutePlan postgres/src/backend/executor/execMain.c:1711:10
    #11 0x5578a59d1593 in standard_ExecutorRun postgres/src/backend/executor/execMain.c:366:3
    #12 0x5578a59d1228 in ExecutorRun postgres/src/backend/executor/execMain.c:303:3
    #13 0x5578a59fa7dd in postquel_getnext postgres/src/backend/executor/functions.c:1428:3
    #14 0x5578a59fa7dd in fmgr_sql postgres/src/backend/executor/functions.c:1706:15
    #15 0x5578a59e96dc in ExecMakeTableFunctionResult postgres/src/backend/executor/execSRF.c:234:13
    #16 0x5578a5a19ed7 in FunctionNext postgres/src/backend/executor/nodeFunctionscan.c:94:5
    #17 0x5578a59eb915 in ExecScanFetch postgres/src/include/executor/execScan.h:134:9
    #18 0x5578a59eb915 in ExecScanExtended postgres/src/include/executor/execScan.h:195:10
    #19 0x5578a59eb915 in ExecScan postgres/src/backend/executor/execScan.c:59:9
    #20 0x5578a5a19626 in ExecFunctionScan postgres/src/backend/executor/nodeFunctionscan.c:269:9
    #21 0x5578a59e5054 in ExecProcNodeFirst postgres/src/backend/executor/execProcnode.c:469:9
    #22 0x5578a59d1593 in ExecProcNode postgres/src/include/executor/executor.h:315:9
    #23 0x5578a59d1593 in ExecutePlan postgres/src/backend/executor/execMain.c:1711:10
    #24 0x5578a59d1593 in standard_ExecutorRun postgres/src/backend/executor/execMain.c:366:3
    #25 0x5578a59d1228 in ExecutorRun postgres/src/backend/executor/execMain.c:303:3
    #26 0x5578a5f45d8f in PortalRunSelect postgres/src/backend/tcop/pquery.c:946:4
    #27 0x5578a5f454b4 in PortalRun postgres/src/backend/tcop/pquery.c:790:18
    #28 0x5578a5f42e5f in exec_simple_query postgres/src/backend/tcop/postgres.c:1294:10
    #29 0x5578a5f3e7f3 in PostgresMain postgres/src/backend/tcop/postgres.c
    #30 0x5578a5f34536 in BackendMain postgres/src/backend/tcop/backend_startup.c:124:2
    #31 0x5578a5d60e6c in postmaster_child_launch postgres/src/backend/postmaster/launch_backend.c:306:3
    #32 0x5578a5d6a0cb in BackendStartup postgres/src/backend/postmaster/postmaster.c:3612:8
    #33 0x5578a5d6a0cb in ServerLoop postgres/src/backend/postmaster/postmaster.c:1715:6
    #34 0x5578a5d65b8e in PostmasterMain postgres/src/backend/postmaster/postmaster.c:1413:11
    #35 0x5578a5643df9 in main postgres/src/backend/main/main.c:227:4
```

This pull request proposes a change to fix the warning above.