### PR TITLE
Fix dangling assignment of relationpath for Postgres 18.

### DIFF
--- a/pgfincore.c
+++ b/pgfincore.c
@@ -151,7 +151,7 @@ Datum		pgfincore_drawer(PG_FUNCTION_ARGS);
         relpathbackend((rel)->rd_locator, (rel)->rd_backend, (forkname_to_number(text_to_cstring(forkName))))
 #else
 #define relpathpg(rel, forkName) \
-        relpathbackend((rel)->rd_locator, (rel)->rd_backend, (forkname_to_number(text_to_cstring(forkName)))).str
+        pstrdup(relpathbackend((rel)->rd_locator, (rel)->rd_backend, (forkname_to_number(text_to_cstring(forkName)))).str)
 #endif
 
 /*


### PR DESCRIPTION
When compiling pgfincore with Postgres 18, we observed the following compiler warning:

```
pgfincore/pgfincore.c:366:24: error: object backing the pointer 'fctx->relationpath' will be destroyed at the end of the full-expression [-Werror,-Wdangling-assignment]
  366 |                 fctx->relationpath = relpathpg(fctx->rel, forkName);
      |                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pgfincore/pgfincore.c:154:9: note: expanded from macro 'relpathpg'
  154 |         relpathbackend((rel)->rd_locator, (rel)->rd_backend, (forkname_to_number(text_to_cstring(forkName)))).str
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
postgres/src/include/common/relpath.h:143:2: note: expanded from macro 'relpathbackend'
  143 |         GetRelationPath((rlocator).dbOid, (rlocator).spcOid, (rlocator).relNumber, \
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  144 |                                         backend, forknum)
      |                                         ~~~~~~~~~~~~~~~~~
pgfincore/pgfincore.c:640:17: error: object backing the pointer 'relationpath' will be destroyed at the end of the full-expression [-Werror,-Wdangling-assignment]
  640 |         relationpath = relpathpg(rel, forkName);
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~
pgfincore/pgfincore.c:154:9: note: expanded from macro 'relpathpg'
  154 |         relpathbackend((rel)->rd_locator, (rel)->rd_backend, (forkname_to_number(text_to_cstring(forkName)))).str
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
postgres/src/include/common/relpath.h:143:2: note: expanded from macro 'relpathbackend'
  143 |         GetRelationPath((rlocator).dbOid, (rlocator).spcOid, (rlocator).relNumber, \
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  144 |                                         backend, forknum)
      |                                         ~~~~~~~~~~~~~~~~~
pgfincore/pgfincore.c:949:24: error: object backing the pointer 'fctx->relationpath' will be destroyed at the end of the full-expression [-Werror,-Wdangling-assignment]
  949 |                 fctx->relationpath = relpathpg(fctx->rel, forkName);
      |                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pgfincore/pgfincore.c:154:9: note: expanded from macro 'relpathpg'
  154 |         relpathbackend((rel)->rd_locator, (rel)->rd_backend, (forkname_to_number(text_to_cstring(forkName)))).str
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
postgres/src/include/common/relpath.h:143:2: note: expanded from macro 'relpathbackend'
  143 |         GetRelationPath((rlocator).dbOid, (rlocator).spcOid, (rlocator).relNumber, \
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  144 |                                         backend, forknum)
      |                                         ~~~~~~~~~~~~~~~~~
```

From what we notice, `GetRelationPath()` in Postgres 18 returns the relation path as the following struct as an rvalue that lasts for the duration of the assignment only:

```
typedef struct RelPathStr
{
	char		str[REL_PATH_STR_MAXLEN + 1];
} RelPathStr;
```

To keep a reference to the `str` safely, we propose a fix to duplicate it using `pstrdup()` to resolve the compiler warning.