### PR TITLE
Fix pgfincore build failures against PostgreSQL 18/19

### DIFF
--- a/pgfincore.c
+++ b/pgfincore.c
@@ -150,8 +150,9 @@ Datum		pgfincore_drawer(PG_FUNCTION_ARGS);
 #define relpathpg(rel, forkName) \
         relpathbackend((rel)->rd_locator, (rel)->rd_backend, (forkname_to_number(text_to_cstring(forkName))))
 #else
+/* PG 18+: relpathbackend() returns RelPathStr; pstrdup .str to get a palloc'd char * */
 #define relpathpg(rel, forkName) \
-        relpathbackend((rel)->rd_locator, (rel)->rd_backend, (forkname_to_number(text_to_cstring(forkName)))).str
+        pstrdup(relpathbackend((rel)->rd_locator, (rel)->rd_backend, (forkname_to_number(text_to_cstring(forkName)))).str)
 #endif
 
 /*
@@ -458,9 +459,9 @@ pgfadvise_loader_file(char *filename,
 					  bool willneed, bool dontneed, VarBit *databit,
 					  pgfloaderStruct *pgfloader)
 {
-	bits8	*sp;
+	uint8	*sp;
 	int		bitlen;
-	bits8	x;
+	uint8	x;
 	int		i, k;
 
 	/*
@@ -698,8 +699,8 @@ pgfincore_file(char *filename, pgfincoreStruct *pgfncr)
 	int		flag_dirty=1;
 
 	int		len, bitlen;
-	bits8	*r;
-	bits8	x = 0;
+	uint8	*r;
+	uint8	x = 0;
 	register int64 pageIndex;
 
 
@@ -1059,8 +1060,8 @@ pgfincore_drawer(PG_FUNCTION_ARGS)
              *r;
 	int  len,i,k;
 	VarBit *databit;
-	bits8 *sp;
-	bits8 x;
+	uint8 *sp;
+	uint8 x;
 
 	if (PG_ARGISNULL(0))
 		elog(ERROR, "pgfincore_drawer: databit argument shouldn't be NULL");


### PR DESCRIPTION
* Wrap relpathpg macro's PG 18+ branch in pstrdup() Upstream already added the #else branch using .str to access the RelPathStr struct member returned by relpathbackend() in PG 18+, but omitted pstrdup().  The bare .str expression is a char[] member of a temporary struct value; assigning it to the char * fields fctx->relationpath (pgfadvise, pgfincore) and relationpath (pgfadvise_loader) produces "incompatible types" errors from both clang and gcc.  Wrapping in pstrdup() copies the path into a palloc'd buffer and gives callers the same char * they always received.

* Replace bits8 with uint8 throughout bits8 was a PostgreSQL-internal typedef aliasing uint8 that has been removed from the installable server headers.  Four sites are affected: pgfadvise_loader_file (*sp, x), pgfincore_file (*r, x), and pgfincore_drawer (*sp, x).  uint8 is the correct portable replacement and is semantically identical; VARBITS() returns uint8 *, and HIGHBIT / IS_HIGHBIT_SET operate on uint8.

Coded by Claude, tested by me.