### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,8 @@ on:
     branches: ['*']
   pull_request:
     branches: ['*']
+permissions:
+  contents: read
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/klando/pgfincore/security/code-scanning/1](https://github.com/klando/pgfincore/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/main.yml` at the workflow root so it applies to all jobs by default. For this workflow, the least-privilege baseline is `contents: read`, which is sufficient for `actions/checkout@v4` and test execution. This addresses the CodeQL warning without changing functional behavior.

Concretely, insert:

```yml
permissions:
  contents: read
```

between the `on:` trigger section and `jobs:` section (or anywhere at workflow root level). No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
